### PR TITLE
chore(github): Use Exemplar Direct Path for SDK Verify

### DIFF
--- a/.github/workflows/generate-and-test-sdk.yml
+++ b/.github/workflows/generate-and-test-sdk.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: ./generator
         run: |
           mvn clean install
-          mvn exec:java "-Dnamespace=exemplar" "-DsdkVersion=0.0.1-exemplar" "-Dspec=${{ secrets.SPEC_FILE }}"
+          mvn exec:java "-Dnamespace=exemplar" "-DsdkVersion=0.0.1-exemplar" "-Dspec=src/test/resources/exemplar.yaml"
       - uses: actions/upload-artifact@v2
         with:
           name: core


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

### :pencil: Description
- Use exemplar direct path for SDK verify

### :link: Related Issues
N/A
