### PR TITLE
chore(deps-dev): Bump typedoc-plugin-markdown from 4.0.0-next.27 to 4.0.0-next.36 in /generator/src/main/resources/dependencies

### DIFF
--- a/generator/src/main/resources/dependencies/package.json
+++ b/generator/src/main/resources/dependencies/package.json
@@ -13,7 +13,7 @@
     "prettier": "3.1.0",
     "prettier-plugin-organize-imports": "3.2.4",
     "typedoc": "0.25.4",
-    "typedoc-plugin-markdown": "4.0.0-next.27",
+    "typedoc-plugin-markdown": "4.0.0-next.36",
     "typedoc-plugin-missing-exports": "2.1.0"
   }
 }


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

### :pencil: Description
- Bump typedoc-plugin-markdown from 4.0.0-next.27 to 4.0.0-next.36 in /generator/src/main/resources/dependencies

### :link: Related Issues
N/A
