### PR TITLE
fix: remove transaction-id parameter from client methods

### DIFF
--- a/generator/src/main/resources/templates/expediagroup-sdk/api/api.mustache
+++ b/generator/src/main/resources/templates/expediagroup-sdk/api/api.mustache
@@ -24,11 +24,11 @@ export class {{classname}} extends Client {
         super({...configurations, userAgent: {{classname}}.userAgent})
     }
 
-    private static createHeaders(transactionId: string) {
+    private static createHeaders() {
         return {
             'Content-Type': 'application/json',
             'User-Agent': {{classname}}.userAgent,
-            'transaction-id': transactionId,
+            'transaction-id': uuid(),
             'x-sdk-title': {{classname}}.sdkTitle
         }
     }
@@ -40,7 +40,7 @@ export class {{classname}} extends Client {
      {{#queryParams}}* @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, defaults to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (defaults to {{{.}}}){{/defaultValue}}{{/required}}
      {{/queryParams}}{{#bodyParams}}* @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, defaults to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (defaults to {{{.}}}){{/defaultValue}}{{/required}}
      {{/bodyParams}}{{#formParams}}* @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, defaults to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (defaults to {{{.}}}){{/defaultValue}}{{/required}}
-     {{/formParams}}* @param transactionId A unique ID to uniquely identify a request/response cycle (optional, defaults to a random generated UUID)<{{{returnType}}}{{^returnType}}void{{/returnType}}>{{#responses}}{{^is2xx}}
+     {{/formParams}}<{{{returnType}}}{{^returnType}}void{{/returnType}}>{{#responses}}{{^is2xx}}
      * @throws ExpediaGroupApi{{{dataType}}}{{/is2xx}}{{/responses}}
      * @return Promise
      */
@@ -48,7 +48,7 @@ export class {{classname}} extends Client {
         {{#returnProperty}}let responsePromise = {{/returnProperty}}this.axiosClient.request({
             method: '{{httpMethod}}',
             url: '{{#removeLeadingSlash}}{{path}}{{/removeLeadingSlash}}'{{#bodyParam}},
-            headers: {{classname}}.createHeaders(transactionId),
+            headers: {{classname}}.createHeaders(),
             data: Serializer.serialize({{{paramName}}}){{/bodyParam}}
         }).catch(error => {
             if (error instanceof ExpediaGroupError) throw error

--- a/generator/src/main/resources/templates/expediagroup-sdk/api/apiParamsDecleration.mustache
+++ b/generator/src/main/resources/templates/expediagroup-sdk/api/apiParamsDecleration.mustache
@@ -1,1 +1,1 @@
-{{#allParams}}{{>api/apiParam}}, {{/allParams}}transactionId: string = uuid()
+{{#allParams}}{{>api/apiParam}}{{^-last}}, {{/-last}}{{/allParams}}

--- a/generator/src/test/resources/exemplar-docs/client/classes/ExemplarClient.md
+++ b/generator/src/test/resources/exemplar-docs/client/classes/ExemplarClient.md
@@ -32,15 +32,10 @@ client/apis/ExemplarClient.ts:45
 
 ### greetings()
 
-> **greetings**(`transactionId`): `Promise`\<[`Greeting`](../../models/classes/Greeting.md)\>
+> **greetings**(): `Promise`\<[`Greeting`](../../models/classes/Greeting.md)\>
 
 Get a \&quot;Hello $partnerName\&quot; response for an authenticated request
-
-#### Parameters
-
-• **transactionId**: `string`= `undefined`
-
-A unique ID to uniquely identify a request/response cycle (optional, defaults to a random generated UUID)`<Greeting>`
+`<Greeting>`
 
 #### Returns
 


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

### :pencil: Description
- Remove transaction-id parameter from client methods

### :link: Related Issues
N/A
