### PR TITLE
fix: remove removed typedoc hideInPageTOC option

### DIFF
--- a/generator/src/main/resources/templates/expediagroup-sdk/typedoc.mustache
+++ b/generator/src/main/resources/templates/expediagroup-sdk/typedoc.mustache
@@ -16,7 +16,6 @@
   "readme": "none",
 
   "hidePageHeader": true,
-  "hideInPageTOC": true,
   "propertiesFormat": "table",
   "enumMembersFormat": "table",
   "typeDeclarationFormat": "table",

--- a/generator/src/test/resources/exemplar-docs/client/classes/ExemplarClient.md
+++ b/generator/src/test/resources/exemplar-docs/client/classes/ExemplarClient.md
@@ -8,7 +8,7 @@
 
 ## Constructors
 
-### new ExemplarClient(configurations)
+### new ExemplarClient()
 
 > **new ExemplarClient**(`configurations`): [`ExemplarClient`](ExemplarClient.md)
 
@@ -35,7 +35,7 @@ client/apis/ExemplarClient.ts:45
 > **greetings**(): `Promise`\<[`Greeting`](../../models/classes/Greeting.md)\>
 
 Get a \&quot;Hello $partnerName\&quot; response for an authenticated request
-`<Greeting>`
+<Greeting>
 
 #### Returns
 

--- a/generator/src/test/resources/exemplar-docs/client/core/classes/AxiosClientConfigurations.md
+++ b/generator/src/test/resources/exemplar-docs/client/core/classes/AxiosClientConfigurations.md
@@ -4,7 +4,7 @@
 
 ## Constructors
 
-### new AxiosClientConfigurations(endpoint, requestTimeout)
+### new AxiosClientConfigurations()
 
 > **new AxiosClientConfigurations**(`endpoint`, `requestTimeout`): [`AxiosClientConfigurations`](AxiosClientConfigurations.md)
 
@@ -24,7 +24,7 @@ core/src/client/AxiosClientConfigurations.ts:24
 
 ## Properties
 
-| Property | Modifier | Type |
-| :------ | :------ | :------ |
-| `endpoint` | `readonly` | `string` |
-| `requestTimeout` | `readonly` | `number` |
+| Property | Modifier | Type | Default value |
+| :------ | :------ | :------ | :------ |
+| `endpoint` | `readonly` | `string` | `Constant.ENDPOINT` |
+| `requestTimeout` | `readonly` | `number` | `Constant.TEN_SECONDS_IN_MILLIS` |

--- a/generator/src/test/resources/exemplar-docs/models/classes/ErrorCause.md
+++ b/generator/src/test/resources/exemplar-docs/models/classes/ErrorCause.md
@@ -6,7 +6,7 @@ The object used to describe a cause for an error, containing both human-readable
 
 ## Constructors
 
-### new ErrorCause(errorCause)
+### new ErrorCause()
 
 > **new ErrorCause**(`errorCause`): [`ErrorCause`](ErrorCause.md)
 

--- a/generator/src/test/resources/exemplar-docs/models/classes/Greeting.md
+++ b/generator/src/test/resources/exemplar-docs/models/classes/Greeting.md
@@ -4,7 +4,7 @@
 
 ## Constructors
 
-### new Greeting(greeting)
+### new Greeting()
 
 > **new Greeting**(`greeting`): [`Greeting`](Greeting.md)
 

--- a/generator/src/test/resources/exemplar-docs/models/classes/ModelError.md
+++ b/generator/src/test/resources/exemplar-docs/models/classes/ModelError.md
@@ -6,7 +6,7 @@ The object used the describe an error, containing both human-readable and in a m
 
 ## Constructors
 
-### new ModelError(error)
+### new ModelError()
 
 > **new ModelError**(`error`): [`ModelError`](ModelError.md)
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- 

### :link: Related Issues
- 
